### PR TITLE
Cost-based rate limiting

### DIFF
--- a/ThrottlingTroll.AspNet/ThrottlingTrollMiddleware.cs
+++ b/ThrottlingTroll.AspNet/ThrottlingTrollMiddleware.cs
@@ -29,7 +29,7 @@ namespace ThrottlingTroll
             RequestDelegate next,
             ThrottlingTrollOptions options
 
-        ) : base(options.Log, options.CounterStore, options.GetConfigFunc, options.IdentityIdExtractor, options.IntervalToReloadConfigInSeconds)
+        ) : base(options.Log, options.CounterStore, options.GetConfigFunc, options.IdentityIdExtractor, options.CostExtractor, options.IntervalToReloadConfigInSeconds)
         {
             this._next = next;
             this._responseFabric = options.ResponseFabric;

--- a/ThrottlingTroll.AzureFunctions/ThrottlingTrollMiddleware.cs
+++ b/ThrottlingTroll.AzureFunctions/ThrottlingTrollMiddleware.cs
@@ -27,7 +27,7 @@ namespace ThrottlingTroll
         (
             ThrottlingTrollOptions options
 
-        ) : base(options.Log, options.CounterStore, options.GetConfigFunc, options.IdentityIdExtractor, options.IntervalToReloadConfigInSeconds)
+        ) : base(options.Log, options.CounterStore, options.GetConfigFunc, options.IdentityIdExtractor, options.CostExtractor, options.IntervalToReloadConfigInSeconds)
         {
             this._responseFabric = options.ResponseFabric;
         }

--- a/ThrottlingTroll.AzureFunctionsAspNet/ThrottlingTrollMiddleware.cs
+++ b/ThrottlingTroll.AzureFunctionsAspNet/ThrottlingTrollMiddleware.cs
@@ -27,7 +27,7 @@ namespace ThrottlingTroll
         (
             ThrottlingTrollOptions options
 
-        ) : base(options.Log, options.CounterStore, options.GetConfigFunc, options.IdentityIdExtractor, options.IntervalToReloadConfigInSeconds)
+        ) : base(options.Log, options.CounterStore, options.GetConfigFunc, options.IdentityIdExtractor, options.CostExtractor, options.IntervalToReloadConfigInSeconds)
         {
             this._responseFabric = options.ResponseFabric;
         }

--- a/ThrottlingTroll.Core/CounterStores/ICounterStore.cs
+++ b/ThrottlingTroll.Core/CounterStores/ICounterStore.cs
@@ -12,18 +12,26 @@ namespace ThrottlingTroll
         /// <summary>
         /// Gets counter by its key
         /// </summary>
+        /// <param name="key">Counter's key</param>
         Task<long> GetAsync(string key);
 
         /// <summary>
         /// Increments and gets counter by its key.
         /// Also sets TTL for it, but only if the resulting counter is less or equal than maxCounterValueToSetTtl.
         /// </summary>
-        Task<long> IncrementAndGetAsync(string key, DateTimeOffset ttl, long maxCounterValueToSetTtl = 1);
+        /// <param name="key">Counter's key</param>
+        /// <param name="cost">Value to increment by</param>
+        /// <param name="ttl">TTL for this counter</param>
+        /// <param name="maxCounterValueToSetTtl">TTL will only be set, if the counter value is less or equal to this number</param>
+        /// <returns>New counter value</returns>
+        Task<long> IncrementAndGetAsync(string key, long cost, DateTimeOffset ttl, long maxCounterValueToSetTtl = 1);
 
         /// <summary>
         /// Decrements counter by its key.
         /// </summary>
-        Task DecrementAsync(string key);
+        /// <param name="key">Counter's key</param>
+        /// <param name="cost">Value to decrement by</param>
+        Task DecrementAsync(string key, long cost);
 
         /// <summary>
         /// Logging utility to use. Will be set by ThrottlingTroll, so don't override it yourself.

--- a/ThrottlingTroll.Core/CounterStores/MemoryCacheCounterStore.cs
+++ b/ThrottlingTroll.Core/CounterStores/MemoryCacheCounterStore.cs
@@ -40,7 +40,7 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
-        public async Task<long> IncrementAndGetAsync(string key, DateTimeOffset ttl, long maxCounterValueToSetTtl)
+        public async Task<long> IncrementAndGetAsync(string key, long cost, DateTimeOffset ttl, long maxCounterValueToSetTtl)
         {
             await this._asyncLock.WaitAsync();
 
@@ -53,7 +53,7 @@ namespace ThrottlingTroll
                     cacheEntry = new CacheEntry(0, ttl);
                 }
 
-                cacheEntry.Count++;
+                cacheEntry.Count += cost;
 
                 if (cacheEntry.Count <= maxCounterValueToSetTtl)
                 {
@@ -76,7 +76,7 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
-        public async Task DecrementAsync(string key)
+        public async Task DecrementAsync(string key, long cost)
         {
             await this._asyncLock.WaitAsync();
 
@@ -89,7 +89,7 @@ namespace ThrottlingTroll
                     return;
                 }
 
-                cacheEntry.Count--;
+                cacheEntry.Count -= cost;
 
                 if (cacheEntry.Count > 0)
                 {

--- a/ThrottlingTroll.Core/RateLimitMethods/FixedWindowRateLimitMethod.cs
+++ b/ThrottlingTroll.Core/RateLimitMethods/FixedWindowRateLimitMethod.cs
@@ -17,7 +17,7 @@ namespace ThrottlingTroll
         public int IntervalInSeconds { get; set; }
 
         /// <inheritdoc />
-        public override async Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+        public override async Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
         {
             if (this.IntervalInSeconds <= 0)
             {
@@ -37,7 +37,7 @@ namespace ThrottlingTroll
             var ttl = now - TimeSpan.FromMilliseconds(now.Millisecond) + TimeSpan.FromSeconds(this.IntervalInSeconds);
 
             // Now checking the actual count
-            long count = await store.IncrementAndGetAsync(limitKey, ttl);
+            long count = await store.IncrementAndGetAsync(limitKey, cost, ttl);
 
             if (count > this.PermitLimit)
             {
@@ -66,7 +66,7 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
-        public override Task DecrementAsync(string limitKey, ICounterStore store)
+        public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
         {
             // Doing nothing
             return Task.CompletedTask;

--- a/ThrottlingTroll.Core/RateLimitMethods/RateLimitMethod.cs
+++ b/ThrottlingTroll.Core/RateLimitMethods/RateLimitMethod.cs
@@ -16,10 +16,10 @@ namespace ThrottlingTroll
         public int PermitLimit { get; set; }
 
         /// <summary>
-        /// Increments the counter and checks if limit of calls is exceeded for a given rule (identified by its hash).
+        /// Increments the counter by cost and checks if limit of calls is exceeded for a given rule (identified by its hash).
         /// If exceeded, returns number of seconds to retry after. Otherwise returns 0.
         /// </summary>
-        public abstract Task<int> IsExceededAsync(string limitKey, ICounterStore store);
+        public abstract Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store);
 
         /// <summary>
         /// Checks if limit of calls is exceeded for a given rule (identified by its hash).
@@ -28,10 +28,10 @@ namespace ThrottlingTroll
         public abstract Task<bool> IsStillExceededAsync(string limitKey, ICounterStore store);
 
         /// <summary>
-        /// Decrements the given counter _if the rate limit method supports this functionality_.
+        /// Decrements the given counter by cost _if the rate limit method supports this functionality_.
         /// Otherwise should do nothing.
         /// </summary>
-        public abstract Task DecrementAsync(string limitKey, ICounterStore store);
+        public abstract Task DecrementAsync(string limitKey, long cost, ICounterStore store);
 
         /// <summary>
         /// Whether ThrottlingTroll's internal failures should result in exceptions or in just log entries.

--- a/ThrottlingTroll.Core/RateLimitMethods/SemaphoreRateLimitMethod.cs
+++ b/ThrottlingTroll.Core/RateLimitMethods/SemaphoreRateLimitMethod.cs
@@ -22,17 +22,17 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
-        public override async Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+        public override async Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
         {
             var now = DateTime.UtcNow;
 
             var ttl = now + TimeSpan.FromSeconds(this.TimeoutInSeconds);
 
-            long count = await store.IncrementAndGetAsync(limitKey, ttl, this.PermitLimit);
+            long count = await store.IncrementAndGetAsync(limitKey, cost, ttl, this.PermitLimit);
 
             if (count > this.PermitLimit)
             {
-                await store.DecrementAsync(limitKey);
+                await store.DecrementAsync(limitKey, cost);
 
                 return this.TimeoutInSeconds;
             }
@@ -51,9 +51,9 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
-        public override Task DecrementAsync(string limitKey, ICounterStore store)
+        public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
         {
-            return store.DecrementAsync(limitKey);
+            return store.DecrementAsync(limitKey, cost);
         }
     }
 }

--- a/ThrottlingTroll.Core/RateLimitMethods/SlidingWindowRateLimitMethod.cs
+++ b/ThrottlingTroll.Core/RateLimitMethods/SlidingWindowRateLimitMethod.cs
@@ -24,7 +24,7 @@ namespace ThrottlingTroll
         public int NumOfBuckets { get; set; }
 
         /// <inheritdoc />
-        public override async Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+        public override async Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
         {
             if (this.IntervalInSeconds <= 0 || this.NumOfBuckets <= 0)
             {
@@ -49,7 +49,7 @@ namespace ThrottlingTroll
             var ttl = now - TimeSpan.FromMilliseconds(now.Millisecond) + TimeSpan.FromSeconds(bucketSizeInSeconds * this.NumOfBuckets);
 
             // Incrementing and getting the current bucket
-            tasks.Add(store.IncrementAndGetAsync(curBucketKey, ttl));
+            tasks.Add(store.IncrementAndGetAsync(curBucketKey, cost, ttl));
 
             // Now checking our local memory cache for the "counter exceeded" flag.
             // Need to do that _after_ the current bucket gets incremented, since for a sliding window the correct count in each bucket matters.
@@ -103,7 +103,7 @@ namespace ThrottlingTroll
         }
 
         /// <inheritdoc />
-        public override Task DecrementAsync(string limitKey, ICounterStore store)
+        public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
         {
             // Doing nothing
             return Task.CompletedTask;

--- a/ThrottlingTroll.Core/ThrottlingTroll.cs
+++ b/ThrottlingTroll.Core/ThrottlingTroll.cs
@@ -36,6 +36,7 @@ namespace ThrottlingTroll
             ArgumentNullException.ThrowIfNull(getConfigFunc);
 
             this._identityIdExtractor = identityIdExtractor;
+            this._costExtractor = costExtractor;
             this._counterStore = counterStore;
             this._log = log ?? ((l, s) => { });
             this._counterStore.Log = this._log;

--- a/ThrottlingTroll.Core/ThrottlingTroll.cs
+++ b/ThrottlingTroll.Core/ThrottlingTroll.cs
@@ -14,6 +14,7 @@ namespace ThrottlingTroll
         private readonly Action<LogLevel, string> _log;
         private readonly ICounterStore _counterStore;
         private readonly Func<IHttpRequestProxy, string> _identityIdExtractor;
+        private readonly Func<IHttpRequestProxy, long> _costExtractor;
         private Task<ThrottlingTrollConfig> _getConfigTask;
         private bool _disposed = false;
         private TimeSpan _sleepTimeSpan = TimeSpan.FromMilliseconds(50);
@@ -27,6 +28,7 @@ namespace ThrottlingTroll
             ICounterStore counterStore,
             Func<Task<ThrottlingTrollConfig>> getConfigFunc,
             Func<IHttpRequestProxy, string> identityIdExtractor,
+            Func<IHttpRequestProxy, long> costExtractor,
             int intervalToReloadConfigInSeconds = 0
         )
         {
@@ -58,7 +60,7 @@ namespace ThrottlingTroll
             bool shouldThrowOnExceptions = false;
             try
             {
-                var config = this.ApplyGlobalIdentityIdExtractor(await this._getConfigTask);
+                var config = this.ApplyGlobalExtractors(await this._getConfigTask);
 
                 if (config.Rules == null)
                 {
@@ -81,7 +83,9 @@ namespace ThrottlingTroll
                     // The limit method defines whether we should throw on our internal failures
                     shouldThrowOnExceptions = limit.LimitMethod.ShouldThrowOnFailures;
 
-                    var limitCheckResult = await limit.IsExceededAsync(request, this._counterStore, config.UniqueName, this._log);
+                    long requestCost = limit.GetCost(request);
+
+                    var limitCheckResult = await limit.IsExceededAsync(request, requestCost, this._counterStore, config.UniqueName, this._log);
 
                     if (limitCheckResult == null)
                     {
@@ -92,7 +96,7 @@ namespace ThrottlingTroll
                     if (!limitCheckResult.IsExceeded)
                     {
                         // Decrementing this counter at the end of request processing
-                        cleanupRoutines.Add(() => limit.OnRequestProcessingFinished(this._counterStore, limitCheckResult.CounterId, this._log));
+                        cleanupRoutines.Add(() => limit.OnRequestProcessingFinished(this._counterStore, limitCheckResult.CounterId, requestCost, this._log));
 
                         // The request matched the rule, but the limit was not exceeded.
                         continue;
@@ -108,12 +112,12 @@ namespace ThrottlingTroll
                             if (!await limit.IsStillExceededAsync(this._counterStore, limitCheckResult.CounterId))
                             {
                                 // Doing double-check
-                                limitCheckResult = await limit.IsExceededAsync(request, this._counterStore, config.UniqueName, this._log);
+                                limitCheckResult = await limit.IsExceededAsync(request, requestCost, this._counterStore, config.UniqueName, this._log);
 
                                 if (!limitCheckResult.IsExceeded)
                                 {
                                     // Decrementing this counter at the end of request processing
-                                    cleanupRoutines.Add(() => limit.OnRequestProcessingFinished(this._counterStore, limitCheckResult.CounterId, this._log));
+                                    cleanupRoutines.Add(() => limit.OnRequestProcessingFinished(this._counterStore, limitCheckResult.CounterId, requestCost, this._log));
 
                                     awaitedSuccessfully = true;
 
@@ -191,7 +195,7 @@ namespace ThrottlingTroll
             this._getConfigTask = task;
         }
 
-        private ThrottlingTrollConfig ApplyGlobalIdentityIdExtractor(ThrottlingTrollConfig config)
+        private ThrottlingTrollConfig ApplyGlobalExtractors(ThrottlingTrollConfig config)
         {
             if (config.Rules != null)
             {
@@ -200,6 +204,11 @@ namespace ThrottlingTroll
                     if (rule.IdentityIdExtractor == null)
                     {
                         rule.IdentityIdExtractor = this._identityIdExtractor;
+                    }
+
+                    if (rule.CostExtractor == null)
+                    {
+                        rule.CostExtractor = this._costExtractor;
                     }
                 }
             }

--- a/ThrottlingTroll.Core/ThrottlingTrollHandler.cs
+++ b/ThrottlingTroll.Core/ThrottlingTrollHandler.cs
@@ -98,7 +98,7 @@ namespace ThrottlingTroll
 
         ) : base(innerHttpMessageHandler ?? new HttpClientHandler())
         {
-            this._troll = new ThrottlingTroll(log, counterStore ?? new MemoryCacheCounterStore(), async () => config, identityIdExtractor);
+            this._troll = new ThrottlingTroll(log, counterStore ?? new MemoryCacheCounterStore(), async () => config, identityIdExtractor, null);
             this._propagateToIngress = config.PropagateToIngress;
             this._responseFabric = responseFabric;
         }
@@ -123,7 +123,7 @@ namespace ThrottlingTroll
 
                 return config;
 
-            }, options.IdentityIdExtractor, options.IntervalToReloadConfigInSeconds);
+            }, options.IdentityIdExtractor, options.CostExtractor, options.IntervalToReloadConfigInSeconds);
         }
 
         /// <summary>

--- a/ThrottlingTroll.Core/ThrottlingTrollHandler.cs
+++ b/ThrottlingTroll.Core/ThrottlingTrollHandler.cs
@@ -96,9 +96,33 @@ namespace ThrottlingTroll
             Action<LogLevel, string> log = null,
             HttpMessageHandler innerHttpMessageHandler = null
 
+        ) : this(null, identityIdExtractor, responseFabric, counterStore, config, log, innerHttpMessageHandler)
+        {
+        }
+
+        /// <summary>
+        /// Use this ctor when manually creating <see cref="HttpClient"/> instances. 
+        /// </summary>
+        /// <param name="costExtractor">Request's cost extraction routine</param>
+        /// <param name="identityIdExtractor">Identity ID extraction routine to be used for extracting Identity IDs from requests</param>
+        /// <param name="responseFabric">Routine for generating custom HTTP responses and/or controlling built-in retries</param>
+        /// <param name="counterStore">Implementation of <see cref="ICounterStore"/></param>
+        /// <param name="config">Throttling configuration</param>
+        /// <param name="log">Logging utility</param>
+        /// <param name="innerHttpMessageHandler">Instance of <see cref="HttpMessageHandler"/> to use as inner handler. When null, a default <see cref="HttpClientHandler"/> instance will be created.</param>
+        public ThrottlingTrollHandler
+        (
+            Func<IHttpRequestProxy, long> costExtractor,
+            Func<IHttpRequestProxy, string> identityIdExtractor,
+            Func<LimitExceededResult, IHttpRequestProxy, IHttpResponseProxy, CancellationToken, Task> responseFabric,
+            ICounterStore counterStore,
+            ThrottlingTrollEgressConfig config,
+            Action<LogLevel, string> log = null,
+            HttpMessageHandler innerHttpMessageHandler = null
+
         ) : base(innerHttpMessageHandler ?? new HttpClientHandler())
         {
-            this._troll = new ThrottlingTroll(log, counterStore ?? new MemoryCacheCounterStore(), async () => config, identityIdExtractor, null);
+            this._troll = new ThrottlingTroll(log, counterStore ?? new MemoryCacheCounterStore(), async () => config, identityIdExtractor, costExtractor);
             this._propagateToIngress = config.PropagateToIngress;
             this._responseFabric = responseFabric;
         }

--- a/ThrottlingTroll.Core/ThrottlingTrollOptions.cs
+++ b/ThrottlingTroll.Core/ThrottlingTrollOptions.cs
@@ -38,6 +38,11 @@ namespace ThrottlingTroll
         public Func<IHttpRequestProxy, string> IdentityIdExtractor { get; set; }
 
         /// <summary>
+        /// Request's cost extraction routine. The default cost (weight) of a request is 1, but this routine allows to override that.
+        /// </summary>
+        public Func<IHttpRequestProxy, long> CostExtractor { get; set; }
+
+        /// <summary>
         /// Logging utility to use
         /// </summary>
         public Action<LogLevel, string> Log { get; set; }

--- a/ThrottlingTroll.CounterStores.DistributedCache/DistributedCacheCounterStore.cs
+++ b/ThrottlingTroll.CounterStores.DistributedCache/DistributedCacheCounterStore.cs
@@ -66,7 +66,7 @@ namespace ThrottlingTroll.CounterStores.DistributedCache
         }
 
         /// <inheritdoc />
-        public async Task<long> IncrementAndGetAsync(string key, DateTimeOffset ttl, long maxCounterValueToSetTtl)
+        public async Task<long> IncrementAndGetAsync(string key, long cost, DateTimeOffset ttl, long maxCounterValueToSetTtl)
         {
             // This is just a local lock, but it's the best we can do with IDistributedCache
             await this._asyncLock.WaitAsync();
@@ -86,7 +86,7 @@ namespace ThrottlingTroll.CounterStores.DistributedCache
                     cacheEntry = new CacheEntry(bytes);
                 }
 
-                cacheEntry.Count++;
+                cacheEntry.Count += cost;
 
                 if (cacheEntry.Count <= maxCounterValueToSetTtl)
                 {
@@ -104,7 +104,7 @@ namespace ThrottlingTroll.CounterStores.DistributedCache
         }
 
         /// <inheritdoc />
-        public async Task DecrementAsync(string key)
+        public async Task DecrementAsync(string key, long cost)
         {
             // This is just a local lock, but it's the best we can do with IDistributedCache
             await this._asyncLock.WaitAsync();
@@ -122,7 +122,7 @@ namespace ThrottlingTroll.CounterStores.DistributedCache
 
                 cacheEntry = new CacheEntry(bytes);
 
-                cacheEntry.Count--;
+                cacheEntry.Count -= cost;
 
                 if (cacheEntry.Count > 0)
                 {

--- a/samples/ThrottlingTrollSampleWeb/Controllers/TestController.cs
+++ b/samples/ThrottlingTrollSampleWeb/Controllers/TestController.cs
@@ -178,6 +178,18 @@ namespace ThrottlingTrollSampleWeb.Controllers
         }
 
         /// <summary>
+        /// A balance of 10 coins per a fixed window of 20 seconds. Cost of a request is taken from 'cost' query string parameter. 
+        /// </summary>
+        /// <response code="200">OK</response>
+        /// <response code="429">TooManyRequests</response>
+        [HttpGet]
+        [Route("fixed-window-balance-of-10-per-20-seconds")]
+        public string Test11()
+        {
+            return "OK";
+        }
+
+        /// <summary>
         /// Uses a rate-limited HttpClient to make calls to a dummy endpoint. Rate limited to 2 requests per a fixed window of 5 seconds.
         /// </summary>
         /// <response code="200">OK</response>

--- a/samples/ThrottlingTrollSampleWeb/Program.cs
+++ b/samples/ThrottlingTrollSampleWeb/Program.cs
@@ -291,6 +291,34 @@ namespace ThrottlingTrollSampleWeb
                 };
             });
 
+            // Demonstrates how to delay the response instead of returning 429
+            app.UseThrottlingTroll(options =>
+            {
+                options.Config = new ThrottlingTrollConfig
+                {
+                    Rules = new[]
+                    {
+                        new ThrottlingTrollRule
+                        {
+                            UriPattern = "/fixed-window-balance-of-10-per-20-seconds",
+                            LimitMethod = new FixedWindowRateLimitMethod
+                            {
+                                PermitLimit = 10,
+                                IntervalInSeconds = 20
+                            },
+
+                            // Specifying a routine to calculate the cost (weight) of each request
+                            CostExtractor = request =>
+                            {
+                                // Cost comes as a 'cost' query string parameter
+                                string? cost = ((IIncomingHttpRequestProxy)request).Request.Query["cost"];
+
+                                return long.TryParse(cost, out long val) ? val : 1;
+                            }
+                        }
+                    }
+                };
+            });
 
             // </ThrottlingTroll Ingress Configuration>
 

--- a/samples/ThrottlingTrollSampleWeb/ThrottlingTrollSampleWeb.csproj
+++ b/samples/ThrottlingTrollSampleWeb/ThrottlingTrollSampleWeb.csproj
@@ -10,8 +10,11 @@
     <ItemGroup>
         <PackageReference Include="restsharp" Version="108.0.3" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-        <PackageReference Include="ThrottlingTroll" Version="4.0.5" />
-        <PackageReference Include="ThrottlingTroll.CounterStores.Redis" Version="4.0.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\ThrottlingTroll.AspNet\ThrottlingTroll.AspNet.csproj" />
+      <ProjectReference Include="..\..\ThrottlingTroll.CounterStores.Redis\ThrottlingTroll.CounterStores.Redis.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/IntegrationTests/IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests.cs
@@ -88,7 +88,7 @@ namespace IntegrationTests
 
         class MalfunctioningSemaphoreRateLimitMethod : SemaphoreRateLimitMethod
         {
-            public override Task DecrementAsync(string limitKey, ICounterStore store)
+            public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
             {
                 // Emulating endpoint that crushes in the middle and forgets to decrement the counter
                 return Task.CompletedTask;
@@ -132,7 +132,7 @@ namespace IntegrationTests
 
         class ThrowingSemaphoreRateLimitMethod : SemaphoreRateLimitMethod
         {
-            public override Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+            public override Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
             {
                 throw new Exception("Temporary glitch in Redis");
             }
@@ -157,7 +157,7 @@ namespace IntegrationTests
 
         class ThrowingFixedWindowRateLimitMethod : FixedWindowRateLimitMethod
         {
-            public override Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+            public override Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
             {
                 throw new Exception("Temporary glitch in Redis");
             }

--- a/tests/ThrottlingTroll.AspNet.Tests/ThrottlingTrollMiddlewareTests.cs
+++ b/tests/ThrottlingTroll.AspNet.Tests/ThrottlingTrollMiddlewareTests.cs
@@ -219,7 +219,7 @@ namespace ThrottlingTroll.AspNet.Tests
         {
             public readonly int RetryAfterSeconds = DateTimeOffset.UtcNow.Second;
 
-            public override Task DecrementAsync(string limitKey, long count, ICounterStore store)
+            public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
             {
                 return Task.CompletedTask;
             }

--- a/tests/ThrottlingTroll.AspNet.Tests/ThrottlingTrollMiddlewareTests.cs
+++ b/tests/ThrottlingTroll.AspNet.Tests/ThrottlingTrollMiddlewareTests.cs
@@ -218,12 +218,12 @@ namespace ThrottlingTroll.AspNet.Tests
         {
             public readonly int RetryAfterSeconds = DateTimeOffset.UtcNow.Second;
 
-            public override Task DecrementAsync(string limitKey, ICounterStore store)
+            public override Task DecrementAsync(string limitKey, long count, ICounterStore store)
             {
                 return Task.CompletedTask;
             }
 
-            public override async Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+            public override async Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
             {
                 return this.RetryAfterSeconds;
             }

--- a/tests/ThrottlingTroll.AzureFunctions.Tests/ThrottlingTrollMiddlewareTests.cs
+++ b/tests/ThrottlingTroll.AzureFunctions.Tests/ThrottlingTrollMiddlewareTests.cs
@@ -70,12 +70,12 @@ namespace ThrottlingTroll.AzureFunctions.Tests
     {
         public readonly int RetryAfterSeconds = DateTimeOffset.UtcNow.Second;
 
-        public override Task DecrementAsync(string limitKey, ICounterStore store)
+        public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
         {
             return Task.CompletedTask;
         }
 
-        public override async Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+        public override async Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
         {
             return this.RetryAfterSeconds;
         }

--- a/tests/ThrottlingTroll.AzureFunctionsAspNet.Tests/ThrottlingTrollMiddlewareTests.cs
+++ b/tests/ThrottlingTroll.AzureFunctionsAspNet.Tests/ThrottlingTrollMiddlewareTests.cs
@@ -214,12 +214,12 @@ namespace ThrottlingTroll.AzureFunctionsAspNet.Tests
         {
             public readonly int RetryAfterSeconds = DateTimeOffset.UtcNow.Second;
 
-            public override Task DecrementAsync(string limitKey, ICounterStore store)
+            public override Task DecrementAsync(string limitKey, long cost, ICounterStore store)
             {
                 return Task.CompletedTask;
             }
 
-            public override async Task<int> IsExceededAsync(string limitKey, ICounterStore store)
+            public override async Task<int> IsExceededAsync(string limitKey, long cost, ICounterStore store)
             {
                 return this.RetryAfterSeconds;
             }

--- a/tests/ThrottlingTroll.Tests/FixedWindowRateLimitMethodTests.cs
+++ b/tests/ThrottlingTroll.Tests/FixedWindowRateLimitMethodTests.cs
@@ -28,13 +28,13 @@ public class FixedWindowRateLimitMethodTests
 
         for (int i = 0; i < limiter.PermitLimit; i++) 
         {
-            Assert.AreEqual(0, await limiter.IsExceededAsync(key, store));
+            Assert.AreEqual(0, await limiter.IsExceededAsync(key, 1, store));
         }
 
         // Now we should exceed
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
 
         // Now waiting for the next second to start
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Waiting till next second");
@@ -51,11 +51,11 @@ public class FixedWindowRateLimitMethodTests
         // Now we should be good again
         for (int i = 0; i < limiter.PermitLimit; i++)
         {
-            Assert.AreEqual(0, await limiter.IsExceededAsync(key, store));
+            Assert.AreEqual(0, await limiter.IsExceededAsync(key, 1, store));
         }
 
         // Now we should exceed again
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Finished");
     }

--- a/tests/ThrottlingTroll.Tests/MemoryCacheCounterStoreTests.cs
+++ b/tests/ThrottlingTroll.Tests/MemoryCacheCounterStoreTests.cs
@@ -19,7 +19,7 @@ public class MemoryCacheCounterStoreTests
 
         Parallel.For(0, numOfTries, new ParallelOptions { MaxDegreeOfParallelism = numOfTries }, i => {
 
-            store.IncrementAndGetAsync(key, ttl, 1).Wait();
+            store.IncrementAndGetAsync(key, 1, ttl, 1).Wait();
 
         });
 

--- a/tests/ThrottlingTroll.Tests/RedisCounterStoreTests.cs
+++ b/tests/ThrottlingTroll.Tests/RedisCounterStoreTests.cs
@@ -67,7 +67,7 @@ public class RedisCounterStoreTests
 
         var store = new RedisCounterStore(redisMock.Object);
 
-        long result = await store.IncrementAndGetAsync(key, ttl, 1);
+        long result = await store.IncrementAndGetAsync(key, 1, ttl, 1);
 
         // Assert
 

--- a/tests/ThrottlingTroll.Tests/SlidingWindowRateLimitMethodTests.cs
+++ b/tests/ThrottlingTroll.Tests/SlidingWindowRateLimitMethodTests.cs
@@ -31,7 +31,7 @@ public class SlidingWindowRateLimitMethodTests
         var stopAt = DateTime.UtcNow + TimeSpan.FromSeconds(5);
         while (DateTime.UtcNow < stopAt)
         {
-            await limiter.IsExceededAsync(key, store);
+            await limiter.IsExceededAsync(key, 1, store);
         }
 
         // Assert
@@ -88,8 +88,8 @@ public class SlidingWindowRateLimitMethodTests
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Making two requests");
 
-        results.Add(await limiter.IsExceededAsync(key, store));
-        results.Add(await limiter.IsExceededAsync(key, store));
+        results.Add(await limiter.IsExceededAsync(key, 1, store));
+        results.Add(await limiter.IsExceededAsync(key, 1, store));
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Sleeping 1 sec");
 
@@ -97,12 +97,12 @@ public class SlidingWindowRateLimitMethodTests
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Making other two requests");
 
-        results.Add(await limiter.IsExceededAsync(key, store));
-        results.Add(await limiter.IsExceededAsync(key, store));
+        results.Add(await limiter.IsExceededAsync(key, 1, store));
+        results.Add(await limiter.IsExceededAsync(key, 1, store));
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Making final request");
 
-        int finalResult = await limiter.IsExceededAsync(key, store);
+        int finalResult = await limiter.IsExceededAsync(key, 1, store);
 
         // Assert
 
@@ -148,7 +148,7 @@ public class SlidingWindowRateLimitMethodTests
         {
             await Task.Delay(TimeSpan.FromMilliseconds(300));
 
-            results.Add(new Tuple<int, int>(DateTime.UtcNow.Millisecond, await limiter.IsExceededAsync(key, store)));
+            results.Add(new Tuple<int, int>(DateTime.UtcNow.Millisecond, await limiter.IsExceededAsync(key, 1, store)));
         }
 
         // Assert
@@ -192,13 +192,13 @@ public class SlidingWindowRateLimitMethodTests
 
         for (int i = 0; i < limiter.PermitLimit; i++)
         {
-            Assert.AreEqual(0, await limiter.IsExceededAsync(key, store));
+            Assert.AreEqual(0, await limiter.IsExceededAsync(key, 1, store));
         }
 
         // Now we should exceed
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
 
         // Now waiting for the next second to start
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Waiting till next second");
@@ -215,11 +215,11 @@ public class SlidingWindowRateLimitMethodTests
         // Now we should be good again
         for (int i = 0; i < limiter.PermitLimit; i++)
         {
-            Assert.AreEqual(0, await limiter.IsExceededAsync(key, store));
+            Assert.AreEqual(0, await limiter.IsExceededAsync(key, 1, store));
         }
 
         // Now we should exceed again
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Finished");
     }
@@ -249,13 +249,13 @@ public class SlidingWindowRateLimitMethodTests
 
         for (int i = 0; i < limiter.PermitLimit; i++)
         {
-            Assert.AreEqual(0, await limiter.IsExceededAsync(key, store));
+            Assert.AreEqual(0, await limiter.IsExceededAsync(key, 1, store));
         }
 
         // Now we should exceed
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
 
         // Now waiting for two seconds
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Waiting");
@@ -274,11 +274,11 @@ public class SlidingWindowRateLimitMethodTests
         // Now we should be good again
         for (int i = 0; i < limiter.PermitLimit; i++)
         {
-            Assert.AreEqual(0, await limiter.IsExceededAsync(key, store));
+            Assert.AreEqual(0, await limiter.IsExceededAsync(key, 1, store));
         }
 
         // Now we should exceed again
-        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, store));
+        Assert.AreNotEqual(0, await limiter.IsExceededAsync(key, 1, store));
 
         Trace.WriteLine($"{DateTime.Now.ToString("o")} Finished");
     }

--- a/tests/ThrottlingTroll.Tests/ThrottlingTrollHandlerTests.cs
+++ b/tests/ThrottlingTroll.Tests/ThrottlingTrollHandlerTests.cs
@@ -64,7 +64,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -105,7 +105,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -142,7 +142,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -195,7 +195,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -277,7 +277,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -318,7 +318,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -355,7 +355,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -408,7 +408,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig

--- a/tests/ThrottlingTroll.Tests/ThrottlingTrollHandlerTests.cs
+++ b/tests/ThrottlingTroll.Tests/ThrottlingTrollHandlerTests.cs
@@ -64,7 +64,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -105,7 +105,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -142,7 +142,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -195,7 +195,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -277,7 +277,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -318,7 +318,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -355,7 +355,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig
@@ -408,7 +408,7 @@ public class ThrottlingTrollHandlerTests
         var counterStoreMock = new Mock<ICounterStore>();
 
         counterStoreMock
-            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1))
+            .Setup(s => s.IncrementAndGetAsync(It.IsAny<string>(), 1L, It.IsAny<DateTimeOffset>(), 1L))
             .Returns(Task.FromResult(2L));
 
         var options = new ThrottlingTrollEgressConfig


### PR DESCRIPTION
Adds a `ThrottlingTrollRule.CostExtractor` routine, which can be provided to customize the cost (weight) of each particular request.
The default cost is 1, but now it is possible to have more and less 'expensive' requests and 'charge' the client accordingly.